### PR TITLE
Configure the heading HTML element for the child pages titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are some configurations options that guide how the output should be displa
 | Filter on Page Label | *string value*  | Include only subpages with the specified label. |
 | Order                | *Nav Order*, *Reverse Nav Order*, *Alphabetical*, *Reverse Alphabetical*, *Create Date*, *Reverse Create Date* | In what order should the child pages be displayed? **Nav Order** refers to the order of the child pages in the page tree. **Reverse Nav Order** simply reverses that. |
 | Limit | *integer value*  | The number of pages to include. If the number is not specified all pages will be included. |
+| HeadingElement | *string value*  | The HTML element type to use for the titles of the child pages. Defaults to H1. |
 
 ## Trivia
 

--- a/include_pages_macro.vm
+++ b/include_pages_macro.vm
@@ -12,6 +12,10 @@
 ## Date updated: 26/3/2016
 ## Added: parent page selector, the possibility to limit the number of pages included.
 ##
+## Updated by: Ronald van Rij
+## Date updated: 29/4/2016
+## Added: allow setting the html element to use for page titles
+##
 
 ## @param ParentPage:title=Parent Page Title|type=confluence-content|desc=Include children of a specific parent page. If no page is defined, current page will be selected.
 ## @param ShowTitle:title=Show Title|type=boolean|desc=Deselect to remove the title of the child page.|default=true
@@ -21,6 +25,7 @@
 ## @param FilterLabel:title=Filter on Page Label|type=string|desc=Include only subpages with the specified label.
 ## @param Order:title=Order|type=enum|enumValues=Nav Order,Reverse Nav Order,Alphabetical,Reverse Alphabetical,Create Date,Reverse Create Date|default=nav order|desc=In what order should the child pages be displayed? Nav Order refers to the order of the child pages in the page tree. Reverse Nav Order simply reverses that.
 ## @param Limit:title=Limit|type=int|default=|desc=The number of pages to include. If number is not specified all pages will be included.
+## @param HeadingElement:title=HeadingElement|type=string|default=h1|desc=The HTML element to be used for the page titles, defaults to H1
 
 #set( $containerManagerClass=$content.class.forName('com.atlassian.spring.container.ContainerManager') )
 #set( $getInstanceMethod=$containerManagerClass.getDeclaredMethod('getInstance',null) )
@@ -97,9 +102,9 @@
         ## Show title and links.
         #if( $paramShowTitle == true )
             #if( $paramLinkTitle == true )
-                #set( $include = $include + '<h1 class="included-child-page-title"><a href="' + $child.getUrlPath() + '">' + $child.getTitle() + '</a></h1>' )
+                #set( $include = $include + '<'+$paramHeadingElement+' class="included-child-page-title"><a href="' + $child.getUrlPath() + '">' + $child.getTitle() + '</a></'+$paramHeadingElement+'>' )
             #else
-                #set( $include = $include + '<h1 class="included-child-page-title">' + $child.getTitle() + '</h1>' )
+                #set( $include = $include + '<'+$paramHeadingElement+' class="included-child-page-title">' + $child.getTitle() + '</'+$paramHeadingElement+'>' )
             #end
         #end
 


### PR DESCRIPTION
I am using the macro to create one large page containing all content of the child pages of another page. But since these child pages are in fact sub pages of another page which is also included, the child page titles need to become h2 elements instead of h1 elements. So: adding the configuration option to the macro to get this to work backwards compatible. 